### PR TITLE
修复一个小概率的BUG

### DIFF
--- a/time_wheel.go
+++ b/time_wheel.go
@@ -109,8 +109,13 @@ func (t *TimerWheel) scheduleTimeOut(timeOut *WheelTimeOut) (string, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	stopIndex := t.wheelCursor + int(relativeIndex)
-	timeOut.index = stopIndex
-	timeOut.rounds = int(remainingRounds)
+	if stopIndex > default_wheel_count {
+		timeOut.index = stopIndex - default_wheel_count
+		timeOut.rounds = int(remainingRounds) + 1
+	} else {
+		timeOut.index = stopIndex
+		timeOut.rounds = int(remainingRounds)
+	}
 	item := t.wheel[stopIndex]
 	if item == nil {
 		item = &Iterator{

--- a/time_wheel.go
+++ b/time_wheel.go
@@ -109,7 +109,7 @@ func (t *TimerWheel) scheduleTimeOut(timeOut *WheelTimeOut) (string, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	stopIndex := t.wheelCursor + int(relativeIndex)
-	if stopIndex > default_wheel_count {
+	if stopIndex >= default_wheel_count {
 		stopIndex = stopIndex - default_wheel_count
 		timeOut.rounds = int(remainingRounds) + 1
 	} else {

--- a/time_wheel.go
+++ b/time_wheel.go
@@ -110,12 +110,12 @@ func (t *TimerWheel) scheduleTimeOut(timeOut *WheelTimeOut) (string, error) {
 	defer t.lock.Unlock()
 	stopIndex := t.wheelCursor + int(relativeIndex)
 	if stopIndex > default_wheel_count {
-		timeOut.index = stopIndex - default_wheel_count
+		stopIndex = stopIndex - default_wheel_count
 		timeOut.rounds = int(remainingRounds) + 1
 	} else {
-		timeOut.index = stopIndex
 		timeOut.rounds = int(remainingRounds)
 	}
+	timeOut.index = stopIndex
 	item := t.wheel[stopIndex]
 	if item == nil {
 		item = &Iterator{


### PR DESCRIPTION
计算完relativeIndex以后，stopIndex := t.wheelCursor + int(relativeIndex)。这句有可能stopIndex还是大于总的槽位数量的，这个时候会抛一个out of bounds。简单处理一下，如果大于最大槽位数量，减去一圈的数量，把圈数增加1
